### PR TITLE
feat: optional table columns, compact density, read-only detail view and resume selection (#13)

### DIFF
--- a/frontend/apps/web/app/applications/ApplicationDetailDialog.tsx
+++ b/frontend/apps/web/app/applications/ApplicationDetailDialog.tsx
@@ -1,0 +1,264 @@
+"use client"
+
+import type { ReactNode } from "react"
+import { CalendarDays, ExternalLink, History, Pencil } from "lucide-react"
+import { Badge } from "@workspace/ui/components/badge"
+import { Button } from "@workspace/ui/components/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@workspace/ui/components/dialog"
+import { Field, FieldGroup, FieldLabel } from "@workspace/ui/components/field"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@workspace/ui/components/tooltip"
+import { formatResumeColumn } from "@/lib/formatResumeColumn"
+import { formatDate } from "@/lib/display"
+import type { ApplicationResponse, CompanyResponse, ResumeResponse } from "@/types"
+
+interface Props {
+  application: ApplicationResponse | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  platforms: Record<number, string>
+  resumeMap: Record<number, ResumeResponse>
+  companies: CompanyResponse[]
+  archived: boolean
+  locale: string
+  onEdit: (app: ApplicationResponse) => void
+  onOpenHistory: (applicationId: number) => void
+  onOpenAppointments: (app: ApplicationResponse) => void
+}
+
+function ReadonlyValue({ children }: { children: ReactNode }) {
+  return <p className="text-sm break-words">{children}</p>
+}
+
+function EmptyValue() {
+  return <p className="text-sm text-muted-foreground">—</p>
+}
+
+export function ApplicationDetailDialog({
+  application,
+  open,
+  onOpenChange,
+  platforms,
+  resumeMap,
+  companies,
+  archived,
+  locale,
+  onEdit,
+  onOpenHistory,
+  onOpenAppointments,
+}: Props) {
+  if (application === null) {
+    return null
+  }
+
+  const companyRecord =
+    application.company_id != null
+      ? companies.find((c) => c.id === application.company_id)
+      : undefined
+
+  function closeAndEdit() {
+    onOpenChange(false)
+    onEdit(application)
+  }
+
+  function closeAndHistory() {
+    onOpenChange(false)
+    onOpenHistory(application.id)
+  }
+
+  function closeAndAppointments() {
+    onOpenChange(false)
+    onOpenAppointments(application)
+  }
+
+  const salaryNum =
+    application.salary != null && application.salary !== "" ? Number(application.salary) : null
+  const salaryText =
+    salaryNum != null && !Number.isNaN(salaryNum)
+      ? new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(salaryNum)
+      : null
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[min(90vh,720px)] overflow-y-auto sm:max-w-lg">
+        <TooltipProvider>
+          <DialogHeader className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1 pr-8">
+              <DialogTitle className="text-left">{application.job_title}</DialogTitle>
+              {application.company ? (
+                <p className="text-sm text-muted-foreground">{application.company}</p>
+              ) : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-1">
+              {!archived && (
+                <>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button type="button" variant="ghost" size="sm" onClick={closeAndAppointments}>
+                        <CalendarDays />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Appointments</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button type="button" variant="ghost" size="sm" onClick={closeAndHistory}>
+                        <History />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>History</TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button type="button" variant="ghost" size="sm" onClick={closeAndEdit}>
+                        <Pencil />
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Edit</TooltipContent>
+                  </Tooltip>
+                </>
+              )}
+              {application.application_url ? (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button variant="ghost" size="sm" asChild>
+                      <a href={application.application_url} target="_blank" rel="noopener noreferrer">
+                        <ExternalLink />
+                      </a>
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Open application URL</TooltipContent>
+                </Tooltip>
+              ) : null}
+            </div>
+          </DialogHeader>
+
+          <FieldGroup className="pt-2">
+          <Field className="gap-1">
+            <FieldLabel>Platform</FieldLabel>
+            <ReadonlyValue>
+              {platforms[application.platform_id] ?? application.platform_id}
+            </ReadonlyValue>
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Company</FieldLabel>
+            {application.company ? (
+              companyRecord?.website ? (
+                <a
+                  href={companyRecord.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-primary underline-offset-4 hover:underline"
+                >
+                  {application.company}
+                </a>
+              ) : (
+                <ReadonlyValue>{application.company}</ReadonlyValue>
+              )
+            ) : (
+              <EmptyValue />
+            )}
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Salary</FieldLabel>
+            {salaryText != null ? <ReadonlyValue>{salaryText}</ReadonlyValue> : <EmptyValue />}
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Seniority</FieldLabel>
+            {application.seniority ? (
+              <ReadonlyValue>{application.seniority}</ReadonlyValue>
+            ) : (
+              <EmptyValue />
+            )}
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Contract type</FieldLabel>
+            {application.contract_type ? (
+              <ReadonlyValue>{application.contract_type}</ReadonlyValue>
+            ) : (
+              <EmptyValue />
+            )}
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Application URL</FieldLabel>
+            {application.application_url ? (
+              <a
+                href={application.application_url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-sm text-primary underline-offset-4 hover:underline break-all"
+              >
+                {application.application_url}
+              </a>
+            ) : (
+              <EmptyValue />
+            )}
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Current stage</FieldLabel>
+            <div className="flex flex-col gap-1">
+              <Badge variant="secondary">{application.current_stage}</Badge>
+              <p className="text-xs text-muted-foreground">
+                Stage changes are made via the History dialog.
+              </p>
+            </div>
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Status</FieldLabel>
+            <Badge variant="outline">{application.status}</Badge>
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Date applied</FieldLabel>
+            <ReadonlyValue>{formatDate(application.applied_at, locale)}</ReadonlyValue>
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Resume</FieldLabel>
+            {application.resume_id != null ? (
+              <ReadonlyValue>
+                {formatResumeColumn(application.resume_id, resumeMap)}
+              </ReadonlyValue>
+            ) : (
+              <EmptyValue />
+            )}
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Created</FieldLabel>
+            <ReadonlyValue>{formatDate(application.created_at, locale)}</ReadonlyValue>
+          </Field>
+
+          <Field className="gap-1">
+            <FieldLabel>Last updated</FieldLabel>
+            <ReadonlyValue>{formatDate(application.updated_at, locale)}</ReadonlyValue>
+          </Field>
+
+          {application.archived_at ? (
+            <Field className="gap-1">
+              <FieldLabel>Archived</FieldLabel>
+              <ReadonlyValue>{formatDate(application.archived_at, locale)}</ReadonlyValue>
+            </Field>
+          ) : null}
+          </FieldGroup>
+        </TooltipProvider>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/apps/web/app/applications/ApplicationForm.tsx
+++ b/frontend/apps/web/app/applications/ApplicationForm.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useForm } from "react-hook-form"
 import { toast } from "sonner"
 import { Button } from "@workspace/ui/components/button"
@@ -16,9 +16,17 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@workspace/ui/
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
 import { Popover, PopoverContent, PopoverTrigger } from "@workspace/ui/components/popover"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@workspace/ui/components/select"
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@workspace/ui/components/select"
 import { useCompanies } from "@/hooks/useCompanies"
 import { usePlatforms } from "@/hooks/usePlatforms"
+import { useResumeMap } from "@/hooks/useResumeMap"
 import { createApplication, updateApplication } from "@/services/applications.service"
 import type {
   ApplicationCreate,
@@ -27,6 +35,8 @@ import type {
   CompanyResponse,
   JobPlatformResponse,
 } from "@/types"
+
+const NO_RESUME_VALUE = "__none__"
 
 const STAGE_SUGGESTIONS = ["application", "screening", "interview", "assessment", "offer", "closed"]
 const STATUS_SUGGESTIONS = ["active", "in_progress", "closed", "rejected", "offered"]
@@ -55,6 +65,12 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
   const isEdit = selectedApplication !== null
   const { data: platforms } = usePlatforms()
   const { data: companies } = useCompanies()
+  const { map: resumeMap, isLoading: resumesLoading, error: resumesError } = useResumeMap()
+
+  const resumesSorted = useMemo(
+    () => Object.values(resumeMap).sort((a, b) => a.name.localeCompare(b.name)),
+    [resumeMap],
+  )
 
   const { register, handleSubmit, reset, setValue, watch } = useForm<FormValues>()
 
@@ -168,6 +184,20 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
   const currentStageValue = watch("current_stage")
   const statusValue = watch("status")
   const platformValue = watch("platform_id")
+  const resumeIdValue = watch("resume_id")
+
+  const resumeSelectValue =
+    resumeIdValue && resumeIdValue !== "" ? resumeIdValue : NO_RESUME_VALUE
+
+  const parsedResumeId = resumeIdValue ? parseInt(resumeIdValue, 10) : NaN
+  const orphanResumeId =
+    resumeIdValue !== "" &&
+    resumeIdValue != null &&
+    Number.isFinite(parsedResumeId) &&
+    resumeMap[parsedResumeId] === undefined
+      ? parsedResumeId
+      : null
+  const hasOrphanResume = orphanResumeId != null
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -286,6 +316,42 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
           <div className="space-y-1">
             <Label htmlFor="application_url">Application URL</Label>
             <Input id="application_url" type="url" {...register("application_url")} placeholder="https://…" />
+          </div>
+
+          <div className="space-y-1">
+            <Label>Resume</Label>
+            {resumesLoading ? (
+              <p className="text-sm text-muted-foreground">Loading resumes…</p>
+            ) : resumesError ? (
+              <p className="text-sm text-destructive">{resumesError}</p>
+            ) : (
+              <Select
+                value={hasOrphanResume ? String(orphanResumeId) : resumeSelectValue}
+                onValueChange={(v) =>
+                  setValue("resume_id", v === NO_RESUME_VALUE ? "" : v)
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="No resume" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectItem value={NO_RESUME_VALUE}>No resume</SelectItem>
+                    {hasOrphanResume ? (
+                      <SelectItem value={String(orphanResumeId)}>
+                        Resume #{orphanResumeId} (removed or unavailable)
+                      </SelectItem>
+                    ) : null}
+                    {resumesSorted.map((r) => (
+                      <SelectItem key={r.id} value={String(r.id)}>
+                        {r.name}
+                        {r.archived_at ? " (archived)" : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                </SelectContent>
+              </Select>
+            )}
           </div>
 
           <div className="grid grid-cols-2 gap-3">

--- a/frontend/apps/web/app/applications/ApplicationTable.tsx
+++ b/frontend/apps/web/app/applications/ApplicationTable.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import {
   createColumnHelper,
   flexRender,
@@ -8,6 +8,7 @@ import {
   getPaginationRowModel,
   getSortedRowModel,
   useReactTable,
+  type ColumnDef,
   type SortingState,
 } from "@tanstack/react-table"
 import { Archive, CalendarDays, ExternalLink, History, Pencil, RotateCcw, Trash2 } from "lucide-react"
@@ -39,16 +40,22 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@workspace/ui/components/tooltip"
+import { cn } from "@workspace/ui/lib/utils"
 import { AppointmentListDialog } from "@/components/AppointmentListDialog"
 import { StageHistoryDialog } from "@/components/StageHistoryDialog"
 import { formatDate } from "@/lib/display"
+import { formatResumeColumn } from "@/lib/formatResumeColumn"
+import { useApplicationsTablePreferences } from "@/hooks/useApplicationsTablePreferences"
 import { usePreference } from "@/hooks/usePreference"
 import { archiveApplication, deleteApplication, restoreApplication } from "@/services/applications.service"
-import type { ApplicationResponse } from "@/types"
+import type { ApplicationResponse, CompanyResponse, ResumeResponse } from "@/types"
+import { ApplicationDetailDialog } from "./ApplicationDetailDialog"
 
 interface Props {
   data: ApplicationResponse[]
   platforms: Record<number, string>
+  resumeMap: Record<number, ResumeResponse>
+  companies: CompanyResponse[]
   archived: boolean
   onEdit: (application: ApplicationResponse) => void
   onRefresh: (updater?: (current: ApplicationResponse[]) => ApplicationResponse[]) => void
@@ -56,80 +63,195 @@ interface Props {
 
 const columnHelper = createColumnHelper<ApplicationResponse>()
 
-export function ApplicationTable({ data, platforms, archived, onEdit, onRefresh }: Props) {
+export function ApplicationTable({
+  data,
+  platforms,
+  resumeMap,
+  companies,
+  archived,
+  onEdit,
+  onRefresh,
+}: Props) {
   const [locale] = usePreference<string>("display.locale", "en-US")
+  const [tablePrefs] = useApplicationsTablePreferences()
   const [sorting, setSorting] = useState<SortingState>([])
   const [historyAppId, setHistoryAppId] = useState<number | null>(null)
   const [appointmentsApp, setAppointmentsApp] = useState<ApplicationResponse | null>(null)
+  const [detailApp, setDetailApp] = useState<ApplicationResponse | null>(null)
 
-  async function handleArchive(id: number) {
-    onRefresh((current) =>
-      current.map((app) => (app.id === id ? { ...app, archived_at: new Date().toISOString() } : app)),
-    )
-    const result = await archiveApplication(id)
-    if (result.error) {
-      toast.error(result.error)
-      onRefresh((current) => current.map((app) => (app.id === id ? { ...app, archived_at: null } : app)))
-    } else {
-      toast.success("Application archived")
-      onRefresh()
+  const handleArchive = useCallback(
+    async (id: number) => {
+      onRefresh((current) =>
+        current.map((app) => (app.id === id ? { ...app, archived_at: new Date().toISOString() } : app)),
+      )
+      const result = await archiveApplication(id)
+      if (result.error) {
+        toast.error(result.error)
+        onRefresh((current) => current.map((app) => (app.id === id ? { ...app, archived_at: null } : app)))
+      } else {
+        toast.success("Application archived")
+        onRefresh()
+      }
+    },
+    [onRefresh],
+  )
+
+  const handleRestore = useCallback(
+    async (id: number) => {
+      onRefresh((current) =>
+        current.map((app) => (app.id === id ? { ...app, archived_at: null } : app)),
+      )
+      const result = await restoreApplication(id)
+      if (result.error) {
+        toast.error(result.error)
+        onRefresh()
+      } else {
+        toast.success("Application restored")
+        onRefresh()
+      }
+    },
+    [onRefresh],
+  )
+
+  const handleDelete = useCallback(
+    async (id: number) => {
+      onRefresh((current) => current.filter((app) => app.id !== id))
+      const result = await deleteApplication(id)
+      if (result.error) {
+        toast.error(result.error)
+        onRefresh()
+      } else {
+        toast.success("Application deleted")
+        onRefresh()
+      }
+    },
+    [onRefresh],
+  )
+
+  const columns = useMemo((): ColumnDef<ApplicationResponse>[] => {
+    const base: ColumnDef<ApplicationResponse>[] = [
+      columnHelper.accessor("job_title", {
+        header: "Job Title",
+        cell: ({ row, getValue }) => (
+          <Button
+            type="button"
+            variant="link"
+            className="h-auto max-w-[min(100%,16rem)] justify-start truncate p-0 font-medium"
+            onClick={() => setDetailApp(row.original)}
+          >
+            {getValue()}
+          </Button>
+        ),
+      }),
+      columnHelper.accessor("company", {
+        header: "Company",
+        cell: (info) => info.getValue() ?? <span className="text-muted-foreground">—</span>,
+      }),
+      columnHelper.accessor("platform_id", {
+        header: "Platform",
+        cell: (info) => platforms[info.getValue()] ?? info.getValue(),
+      }),
+      columnHelper.accessor("status", {
+        header: "Status",
+        cell: (info) => <Badge variant="outline">{info.getValue()}</Badge>,
+      }),
+      columnHelper.accessor("current_stage", {
+        header: "Stage",
+        cell: (info) => <Badge variant="secondary">{info.getValue()}</Badge>,
+      }),
+      columnHelper.accessor("applied_at", {
+        header: "Date Applied",
+        cell: (info) => formatDate(info.getValue(), locale),
+      }),
+    ]
+
+    const optional: ColumnDef<ApplicationResponse>[] = []
+
+    if (tablePrefs.showResumeColumn) {
+      optional.push(
+        columnHelper.accessor((row) => formatResumeColumn(row.resume_id, resumeMap), {
+          id: "resume",
+          header: "Resume",
+          cell: ({ row }) => {
+            const id = row.original.resume_id
+            if (id == null) {
+              return <span className="text-muted-foreground">—</span>
+            }
+            return (
+              <span className="max-w-[14rem] truncate" title={formatResumeColumn(id, resumeMap)}>
+                {formatResumeColumn(id, resumeMap)}
+              </span>
+            )
+          },
+          sortingFn: "alphanumeric",
+        }),
+      )
     }
-  }
 
-  async function handleRestore(id: number) {
-    onRefresh((current) =>
-      current.map((app) => (app.id === id ? { ...app, archived_at: null } : app)),
-    )
-    const result = await restoreApplication(id)
-    if (result.error) {
-      toast.error(result.error)
-      onRefresh()
-    } else {
-      toast.success("Application restored")
-      onRefresh()
+    if (tablePrefs.showSalaryColumn) {
+      optional.push(
+        columnHelper.accessor(
+          (row) => {
+            const s = row.salary
+            if (s == null || s === "") return null
+            const n = Number(s)
+            return Number.isNaN(n) ? null : n
+          },
+          {
+            id: "salary",
+            header: "Salary",
+            cell: ({ row }) => {
+              const s = row.original.salary
+              if (s == null || s === "") {
+                return <span className="text-muted-foreground">—</span>
+              }
+              const n = Number(s)
+              if (Number.isNaN(n)) {
+                return <span className="text-muted-foreground">—</span>
+              }
+              return new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(n)
+            },
+            sortingFn: (a, b, columnId) => {
+              const av = a.getValue(columnId) as number | null
+              const bv = b.getValue(columnId) as number | null
+              if (av == null && bv == null) return 0
+              if (av == null) return 1
+              if (bv == null) return -1
+              return av === bv ? 0 : av < bv ? -1 : 1
+            },
+          },
+        ),
+      )
     }
-  }
 
-  async function handleDelete(id: number) {
-    onRefresh((current) => current.filter((app) => app.id !== id))
-    const result = await deleteApplication(id)
-    if (result.error) {
-      toast.error(result.error)
-      onRefresh()
-    } else {
-      toast.success("Application deleted")
-      onRefresh()
+    if (tablePrefs.showSeniorityColumn) {
+      optional.push(
+        columnHelper.accessor((row) => row.seniority ?? "", {
+          id: "seniority",
+          header: "Seniority",
+          cell: (info) =>
+            info.row.original.seniority ? (
+              info.getValue()
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            ),
+        }),
+      )
     }
-  }
 
-  const columns = [
-    columnHelper.accessor("job_title", {
-      header: "Job Title",
-      cell: (info) => <span className="font-medium">{info.getValue()}</span>,
-    }),
-    columnHelper.accessor("company", {
-      header: "Company",
-      cell: (info) => info.getValue() ?? <span className="text-muted-foreground">—</span>,
-    }),
-    columnHelper.accessor("platform_id", {
-      header: "Platform",
-      cell: (info) => platforms[info.getValue()] ?? info.getValue(),
-    }),
-    columnHelper.accessor("status", {
-      header: "Status",
-      cell: (info) => <Badge variant="outline">{info.getValue()}</Badge>,
-    }),
-    columnHelper.accessor("current_stage", {
-      header: "Stage",
-      cell: (info) => <Badge variant="secondary">{info.getValue()}</Badge>,
-    }),
-    columnHelper.accessor("applied_at", {
-      header: "Date Applied",
-      cell: (info) => formatDate(info.getValue(), locale),
-    }),
-    columnHelper.display({
+    if (tablePrefs.showCreatedAtColumn) {
+      optional.push(
+        columnHelper.accessor("created_at", {
+          id: "created_at",
+          header: "Created",
+          cell: (info) => formatDate(info.getValue(), locale),
+        }),
+      )
+    }
+
+    const actions = columnHelper.display({
       id: "actions",
-      header: () => <span className="text-right block">Actions</span>,
+      header: () => <span className="block text-right">Actions</span>,
       cell: ({ row }) => {
         const app = row.original
         return (
@@ -260,8 +382,10 @@ export function ApplicationTable({ data, platforms, archived, onEdit, onRefresh 
           </div>
         )
       },
-    }),
-  ]
+    })
+
+    return [...base, ...optional, actions]
+  }, [tablePrefs, platforms, resumeMap, locale, archived, onEdit, handleArchive, handleRestore, handleDelete])
 
   const table = useReactTable({
     data,
@@ -276,7 +400,13 @@ export function ApplicationTable({ data, platforms, archived, onEdit, onRefresh 
 
   return (
     <TooltipProvider>
-      <div className="rounded-md border">
+      <div
+        className={cn(
+          "rounded-md border",
+          tablePrefs.compactDensity &&
+            "[&_[data-slot=table-head]]:h-8 [&_[data-slot=table-head]]:px-1.5 [&_[data-slot=table-head]]:text-xs [&_[data-slot=table-cell]]:p-1.5 [&_[data-slot=table-cell]]:text-xs",
+        )}
+      >
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -343,11 +473,31 @@ export function ApplicationTable({ data, platforms, archived, onEdit, onRefresh 
         </div>
       )}
 
+      {detailApp !== null && (
+        <ApplicationDetailDialog
+          application={detailApp}
+          open
+          onOpenChange={(open) => {
+            if (!open) setDetailApp(null)
+          }}
+          platforms={platforms}
+          resumeMap={resumeMap}
+          companies={companies}
+          archived={archived}
+          locale={locale}
+          onEdit={onEdit}
+          onOpenHistory={(id) => setHistoryAppId(id)}
+          onOpenAppointments={(app) => setAppointmentsApp(app)}
+        />
+      )}
+
       {historyAppId !== null && (
         <StageHistoryDialog
           applicationId={historyAppId}
           open={historyAppId !== null}
-          onOpenChange={(open) => { if (!open) setHistoryAppId(null) }}
+          onOpenChange={(open) => {
+            if (!open) setHistoryAppId(null)
+          }}
           onStageChanged={onRefresh}
         />
       )}
@@ -361,7 +511,9 @@ export function ApplicationTable({ data, platforms, archived, onEdit, onRefresh 
               : appointmentsApp.job_title
           }
           open={appointmentsApp !== null}
-          onOpenChange={(open) => { if (!open) setAppointmentsApp(null) }}
+          onOpenChange={(open) => {
+            if (!open) setAppointmentsApp(null)
+          }}
           onRefresh={onRefresh}
         />
       )}

--- a/frontend/apps/web/app/applications/page.tsx
+++ b/frontend/apps/web/app/applications/page.tsx
@@ -1,10 +1,20 @@
 "use client"
 
+import Link from "next/link"
 import { useState } from "react"
+import { Settings } from "lucide-react"
 import { Button } from "@workspace/ui/components/button"
 import { Skeleton } from "@workspace/ui/components/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@workspace/ui/components/tooltip"
 import { useApplications } from "@/hooks/useApplications"
+import { useCompanies } from "@/hooks/useCompanies"
 import { usePlatforms } from "@/hooks/usePlatforms"
+import { useResumeMap } from "@/hooks/useResumeMap"
 import type { ApplicationFilters, ApplicationResponse } from "@/types"
 import { ApplicationFiltersBar } from "./ApplicationFilters"
 import { ApplicationForm } from "./ApplicationForm"
@@ -17,6 +27,8 @@ export default function ApplicationsPage() {
 
   const { data, isLoading, error, refetch, setData } = useApplications(filters)
   const { data: platforms } = usePlatforms()
+  const { map: resumeMap } = useResumeMap()
+  const { data: companies } = useCompanies()
 
   const platformMap = Object.fromEntries(platforms.map((p) => [p.id, p.name])) as Record<number, string>
 
@@ -36,7 +48,19 @@ export default function ApplicationsPage() {
 
       <div className="flex flex-wrap items-end gap-4">
         <ApplicationFiltersBar filters={filters} onChange={setFilters} />
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="icon" asChild>
+                  <Link href="/settings#applications-table" aria-label="Customize table columns">
+                    <Settings />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Customize table columns</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <Button onClick={openCreate}>New Application</Button>
         </div>
       </div>
@@ -53,6 +77,8 @@ export default function ApplicationsPage() {
         <ApplicationTable
           data={data}
           platforms={platformMap}
+          resumeMap={resumeMap}
+          companies={companies}
           archived={filters.archived ?? false}
           onEdit={openEdit}
           onRefresh={(updater) => {

--- a/frontend/apps/web/app/settings/ApplicationsTablePreferencesCard.tsx
+++ b/frontend/apps/web/app/settings/ApplicationsTablePreferencesCard.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card"
+import { Field, FieldGroup, FieldLabel } from "@workspace/ui/components/field"
+import { Switch } from "@workspace/ui/components/switch"
+import { useApplicationsTablePreferences } from "@/hooks/useApplicationsTablePreferences"
+
+export function ApplicationsTablePreferencesCard() {
+  const [prefs, setPrefs] = useApplicationsTablePreferences()
+
+  return (
+    <Card id="applications-table">
+      <CardHeader>
+        <div className="flex flex-col gap-1">
+          <CardTitle className="text-base">Applications table</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Optional columns and row density for the applications list. Job title opens a read-only detail
+            view.
+          </p>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <FieldGroup>
+          <Field>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <FieldLabel>Resume column</FieldLabel>
+                <p className="text-xs text-muted-foreground">
+                  Show linked resume as name and id (e.g. My CV | 3).
+                </p>
+              </div>
+              <Switch
+                checked={prefs.showResumeColumn}
+                onCheckedChange={(checked) =>
+                  setPrefs({ ...prefs, showResumeColumn: checked })
+                }
+                aria-label="Show resume column"
+              />
+            </div>
+          </Field>
+          <Field>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <FieldLabel>Salary column</FieldLabel>
+                <p className="text-xs text-muted-foreground">Show stored salary when present.</p>
+              </div>
+              <Switch
+                checked={prefs.showSalaryColumn}
+                onCheckedChange={(checked) =>
+                  setPrefs({ ...prefs, showSalaryColumn: checked })
+                }
+                aria-label="Show salary column"
+              />
+            </div>
+          </Field>
+          <Field>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <FieldLabel>Seniority column</FieldLabel>
+                <p className="text-xs text-muted-foreground">Show seniority level when set.</p>
+              </div>
+              <Switch
+                checked={prefs.showSeniorityColumn}
+                onCheckedChange={(checked) =>
+                  setPrefs({ ...prefs, showSeniorityColumn: checked })
+                }
+                aria-label="Show seniority column"
+              />
+            </div>
+          </Field>
+          <Field>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <FieldLabel>Created date column</FieldLabel>
+                <p className="text-xs text-muted-foreground">Show when the record was created.</p>
+              </div>
+              <Switch
+                checked={prefs.showCreatedAtColumn}
+                onCheckedChange={(checked) =>
+                  setPrefs({ ...prefs, showCreatedAtColumn: checked })
+                }
+                aria-label="Show created at column"
+              />
+            </div>
+          </Field>
+          <Field>
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col gap-1">
+                <FieldLabel>Compact rows</FieldLabel>
+                <p className="text-xs text-muted-foreground">Tighter padding and slightly smaller text.</p>
+              </div>
+              <Switch
+                checked={prefs.compactDensity}
+                onCheckedChange={(checked) =>
+                  setPrefs({ ...prefs, compactDensity: checked })
+                }
+                aria-label="Compact table density"
+              />
+            </div>
+          </Field>
+        </FieldGroup>
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/apps/web/app/settings/page.tsx
+++ b/frontend/apps/web/app/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+import { ApplicationsTablePreferencesCard } from "./ApplicationsTablePreferencesCard"
 import { Card, CardContent, CardHeader, CardTitle } from "@workspace/ui/components/card"
 import { Field, FieldGroup, FieldLabel } from "@workspace/ui/components/field"
 import { Input } from "@workspace/ui/components/input"
@@ -54,6 +55,18 @@ const TIME_ZONES = [
 
 type TimeZoneValue = (typeof TIME_ZONES)[number] | "auto"
 
+function SettingsHashScroll() {
+  React.useEffect(() => {
+    if (typeof window === "undefined") return
+    if (window.location.hash !== "#applications-table") return
+    const id = window.setTimeout(() => {
+      document.getElementById("applications-table")?.scrollIntoView({ behavior: "smooth", block: "start" })
+    }, 100)
+    return () => window.clearTimeout(id)
+  }, [])
+  return null
+}
+
 export default function SettingsPage() {
   const [widgets, setWidgets] = useDashboardWidgets()
   const [calendarExpanded, setCalendarExpanded] = usePreference<boolean>(
@@ -66,6 +79,7 @@ export default function SettingsPage() {
 
   return (
     <div className="flex flex-col gap-4">
+      <SettingsHashScroll />
       <h1 className="text-2xl font-semibold">Settings</h1>
       <Card>
         <CardHeader>
@@ -198,6 +212,8 @@ export default function SettingsPage() {
           </FieldGroup>
         </CardContent>
       </Card>
+
+      <ApplicationsTablePreferencesCard />
 
       <Card>
         <CardHeader>

--- a/frontend/apps/web/hooks/useApplicationsTablePreferences.ts
+++ b/frontend/apps/web/hooks/useApplicationsTablePreferences.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useMemo } from "react"
+import { usePreference } from "@/hooks/usePreference"
+
+export type ApplicationsTablePreferences = {
+  showResumeColumn: boolean
+  showSalaryColumn: boolean
+  showSeniorityColumn: boolean
+  showCreatedAtColumn: boolean
+  compactDensity: boolean
+}
+
+export const defaultApplicationsTablePreferences: ApplicationsTablePreferences = {
+  showResumeColumn: false,
+  showSalaryColumn: false,
+  showSeniorityColumn: false,
+  showCreatedAtColumn: false,
+  compactDensity: false,
+}
+
+const STORAGE_KEY = "applications.tablePreferences"
+
+export function useApplicationsTablePreferences() {
+  const [stored, setStored] = usePreference<ApplicationsTablePreferences>(
+    STORAGE_KEY,
+    defaultApplicationsTablePreferences,
+  )
+  const prefs = useMemo(
+    () => ({ ...defaultApplicationsTablePreferences, ...stored }),
+    [stored],
+  )
+  function setPrefs(next: ApplicationsTablePreferences) {
+    setStored(next)
+  }
+  return [prefs, setPrefs] as const
+}

--- a/frontend/apps/web/hooks/useResumeMap.ts
+++ b/frontend/apps/web/hooks/useResumeMap.ts
@@ -1,0 +1,44 @@
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+import { getResumes } from "@/services/resumes.service"
+import type { ResumeResponse } from "@/types"
+
+export function useResumeMap() {
+  const [map, setMap] = useState<Record<number, ResumeResponse>>({})
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    const [active, archived] = await Promise.all([getResumes(false), getResumes(true)])
+    if (active.error !== null) {
+      setError(active.error)
+      setMap({})
+      setIsLoading(false)
+      return
+    }
+    if (archived.error !== null) {
+      setError(archived.error)
+      setMap({})
+      setIsLoading(false)
+      return
+    }
+    const merged: Record<number, ResumeResponse> = {}
+    for (const r of archived.data) {
+      merged[r.id] = r
+    }
+    for (const r of active.data) {
+      merged[r.id] = r
+    }
+    setMap(merged)
+    setIsLoading(false)
+  }, [])
+
+  useEffect(() => {
+    fetchData()
+  }, [fetchData])
+
+  return { map, isLoading, error, refetch: fetchData }
+}

--- a/frontend/apps/web/lib/formatResumeColumn.ts
+++ b/frontend/apps/web/lib/formatResumeColumn.ts
@@ -1,0 +1,11 @@
+import type { ResumeResponse } from "@/types"
+
+export function formatResumeColumn(
+  resumeId: number | null | undefined,
+  map: Record<number, ResumeResponse>,
+): string {
+  if (resumeId == null) return ""
+  const resume = map[resumeId]
+  const name = resume?.name ?? "Unknown"
+  return `${name} | ${resumeId}`
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "turbo": "^2.8.8",
     "typescript": "5.9.3"
   },
-  "packageManager": "pnpm@9.0.6",
+  "packageManager": "pnpm@10.32.1",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## Summary
Improves the applications experience with persisted table options, a read-only detail view, and resume selection on create/edit without changing backend contracts for list/detail.

## Changes
- Add `useApplicationsTablePreferences` and Settings card (`#applications-table`) for optional columns (resume, salary, seniority, created) and compact row density
- Add cog + tooltip on Applications linking to `/settings#applications-table` with hash scroll on Settings
- Add `useResumeMap`, `formatResumeColumn` (`{name} | {id}`) for table/detail display
- Add `ApplicationDetailDialog` opened from job title (read-only fields, links, header shortcuts)
- Add resume `Select` to `ApplicationForm` (merged active/archived, orphan handling)
- Refactor `ApplicationTable` for dynamic columns, compact styling, and stable handlers (`useMemo` / `useCallback`)
- Bump frontend packageManager pnpm version


## Notes
- Prework for #7 
- Closes #13 