### PR TITLE
feat(applications): compensation currency & pay period, table column order, and docs (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs
 
 skills-lock.json
 .cursor
+
+
+nul

--- a/backend/alembic/versions/add_salary_currency_pay_period.py
+++ b/backend/alembic/versions/add_salary_currency_pay_period.py
@@ -1,0 +1,21 @@
+"""Add salary_currency and pay_period to application."""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "add_salary_currency_pay_period"
+down_revision: Union[str, None] = "add_company_name_ci_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("application", sa.Column("salary_currency", sa.String(3), nullable=True))
+    op.add_column("application", sa.Column("pay_period", sa.String(20), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("application", "pay_period")
+    op.drop_column("application", "salary_currency")

--- a/backend/app/models/application.py
+++ b/backend/app/models/application.py
@@ -16,6 +16,8 @@ class Application(Base):
     job_title: Mapped[str] = mapped_column(String(255), nullable=False)
     company: Mapped[Optional[str]] = mapped_column(String(255), nullable=True)
     salary: Mapped[Optional[Decimal]] = mapped_column(Numeric(12, 2), nullable=True)
+    salary_currency: Mapped[Optional[str]] = mapped_column(String(3), nullable=True)
+    pay_period: Mapped[Optional[str]] = mapped_column(String(20), nullable=True)
     seniority: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     contract_type: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     application_url: Mapped[Optional[str]] = mapped_column(String(500), nullable=True)

--- a/backend/app/schemas/application.py
+++ b/backend/app/schemas/application.py
@@ -1,8 +1,12 @@
+import re
 from datetime import date, datetime
 from decimal import Decimal
-from typing import Optional
+from typing import Any, Literal, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator, model_validator
+
+
+PayPeriod = Literal["annual", "monthly", "hourly"]
 
 
 class ApplicationCreate(BaseModel):
@@ -10,6 +14,8 @@ class ApplicationCreate(BaseModel):
     job_title: str
     company: Optional[str] = None
     salary: Optional[Decimal] = None
+    salary_currency: Optional[str] = None
+    pay_period: Optional[PayPeriod] = None
     seniority: Optional[str] = None
     contract_type: Optional[str] = None
     application_url: Optional[str] = None
@@ -19,12 +25,33 @@ class ApplicationCreate(BaseModel):
     resume_id: Optional[int] = None
     company_id: Optional[int] = None
 
+    @field_validator("salary_currency", mode="before")
+    @classmethod
+    def normalize_currency(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v == "":
+            return None
+        s = str(v).strip().upper()
+        if not re.fullmatch(r"[A-Z]{3}", s):
+            raise ValueError("salary_currency must be a 3-letter ISO 4217 code")
+        return s
+
+    @model_validator(mode="after")
+    def salary_coherence(self) -> "ApplicationCreate":
+        if self.salary is None:
+            self.salary_currency = None
+            self.pay_period = None
+        elif self.salary_currency is None or self.pay_period is None:
+            raise ValueError("salary_currency and pay_period are required when salary is set")
+        return self
+
 
 class ApplicationUpdate(BaseModel):
     platform_id: Optional[int] = None
     job_title: Optional[str] = None
     company: Optional[str] = None
     salary: Optional[Decimal] = None
+    salary_currency: Optional[str] = None
+    pay_period: Optional[PayPeriod] = None
     seniority: Optional[str] = None
     contract_type: Optional[str] = None
     application_url: Optional[str] = None
@@ -32,6 +59,26 @@ class ApplicationUpdate(BaseModel):
     applied_at: Optional[date] = None
     resume_id: Optional[int] = None
     company_id: Optional[int] = None
+
+    @field_validator("salary_currency", mode="before")
+    @classmethod
+    def normalize_currency_update(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v == "":
+            return None
+        s = str(v).strip().upper()
+        if not re.fullmatch(r"[A-Z]{3}", s):
+            raise ValueError("salary_currency must be a 3-letter ISO 4217 code")
+        return s
+
+    @model_validator(mode="before")
+    @classmethod
+    def salary_coherence_on_patch(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+        if "salary" in data and data["salary"] is not None:
+            if data.get("salary_currency") is None or data.get("pay_period") is None:
+                raise ValueError("salary_currency and pay_period are required when salary is set")
+        return data
 
 
 class ApplicationResponse(BaseModel):
@@ -43,6 +90,8 @@ class ApplicationResponse(BaseModel):
     company: Optional[str]
     company_id: Optional[int]
     salary: Optional[Decimal]
+    salary_currency: Optional[str]
+    pay_period: Optional[str]
     seniority: Optional[str]
     contract_type: Optional[str]
     application_url: Optional[str]

--- a/backend/app/services/application.py
+++ b/backend/app/services/application.py
@@ -9,6 +9,12 @@ from app.core import utcnow
 from app.services.application_history import _append_history_and_update_stage
 
 
+def _normalize_salary_fields(application: Application) -> None:
+    if application.salary is None:
+        application.salary_currency = None
+        application.pay_period = None
+
+
 def get_application(db: Session, application_id: int) -> Application | None:
     return db.query(Application).filter(Application.id == application_id).first()
 
@@ -46,6 +52,8 @@ def create_application(db: Session, data: ApplicationCreate) -> Application:
         company=data.company,
         company_id=data.company_id,
         salary=data.salary,
+        salary_currency=data.salary_currency,
+        pay_period=data.pay_period,
         seniority=data.seniority,
         contract_type=data.contract_type,
         application_url=data.application_url,
@@ -54,6 +62,7 @@ def create_application(db: Session, data: ApplicationCreate) -> Application:
         applied_at=applied_at_dt,
         resume_id=data.resume_id,
     )
+    _normalize_salary_fields(application)
     db.add(application)
     db.flush()
 
@@ -77,6 +86,7 @@ def update_application(db: Session, application_id: int, data: ApplicationUpdate
         if field == "applied_at" and isinstance(value, date) and not isinstance(value, datetime):
             value = datetime.combine(value, time.min)
         setattr(application, field, value)
+    _normalize_salary_fields(application)
     db.commit()
     db.refresh(application)
     return application

--- a/frontend/apps/web/__tests__/ApplicationTable.test.tsx
+++ b/frontend/apps/web/__tests__/ApplicationTable.test.tsx
@@ -12,6 +12,8 @@ const { sampleApp, StageHistoryDialogSpy } = vi.hoisted(() => {
     company: "Globex",
     company_id: null,
     salary: null,
+    salary_currency: null,
+    pay_period: null,
     seniority: null,
     contract_type: null,
     application_url: null,

--- a/frontend/apps/web/__tests__/applications-page.test.tsx
+++ b/frontend/apps/web/__tests__/applications-page.test.tsx
@@ -31,6 +31,8 @@ vi.mock("@/hooks/useApplications", () => ({
         company: "Acme",
         company_id: null,
         salary: null,
+        salary_currency: null,
+        pay_period: null,
         seniority: null,
         contract_type: null,
         application_url: null,

--- a/frontend/apps/web/__tests__/compensation-display.test.ts
+++ b/frontend/apps/web/__tests__/compensation-display.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest"
+import { formatCompensation } from "@/lib/compensation-display"
+
+describe("formatCompensation", () => {
+  it("returns null for empty salary", () => {
+    expect(
+      formatCompensation({
+        salary: null,
+        salary_currency: "USD",
+        pay_period: "annual",
+        locale: "en-US",
+      }),
+    ).toBeNull()
+  })
+
+  it("formats number-only when currency missing", () => {
+    expect(
+      formatCompensation({
+        salary: "50000",
+        salary_currency: null,
+        pay_period: "annual",
+        locale: "en-US",
+      }),
+    ).toBe("50,000/yr")
+  })
+
+  it("formats currency and period suffix", () => {
+    const s = formatCompensation({
+      salary: "75000.5",
+      salary_currency: "USD",
+      pay_period: "annual",
+      locale: "en-US",
+    })
+    expect(s).toContain("75,000.5")
+    expect(s).toContain("/yr")
+    expect(s).toMatch(/\$/)
+  })
+
+  it("handles hourly with BRL", () => {
+    const s = formatCompensation({
+      salary: 50,
+      salary_currency: "BRL",
+      pay_period: "hourly",
+      locale: "pt-BR",
+    })
+    expect(s).toContain("/hr")
+  })
+})

--- a/frontend/apps/web/app/applications/ApplicationDetailDialog.tsx
+++ b/frontend/apps/web/app/applications/ApplicationDetailDialog.tsx
@@ -17,6 +17,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@workspace/ui/components/tooltip"
+import { formatCompensation } from "@/lib/compensation-display"
 import { formatResumeColumn } from "@/lib/formatResumeColumn"
 import { formatDate } from "@/lib/display"
 import type { ApplicationResponse, CompanyResponse, ResumeResponse } from "@/types"
@@ -82,11 +83,12 @@ export function ApplicationDetailDialog({
     onOpenAppointments(app)
   }
 
-  const salaryNum = app.salary != null && app.salary !== "" ? Number(app.salary) : null
-  const salaryText =
-    salaryNum != null && !Number.isNaN(salaryNum)
-      ? new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(salaryNum)
-      : null
+  const salaryText = formatCompensation({
+    salary: app.salary,
+    salary_currency: app.salary_currency,
+    pay_period: app.pay_period,
+    locale,
+  })
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/frontend/apps/web/app/applications/ApplicationForm.tsx
+++ b/frontend/apps/web/app/applications/ApplicationForm.tsx
@@ -13,6 +13,13 @@ import {
   CommandList,
 } from "@workspace/ui/components/command"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@workspace/ui/components/dialog"
+import {
+  Field,
+  FieldDescription,
+  FieldGroup,
+  FieldLabel,
+  FieldTitle,
+} from "@workspace/ui/components/field"
 import { Input } from "@workspace/ui/components/input"
 import { Label } from "@workspace/ui/components/label"
 import { Popover, PopoverContent, PopoverTrigger } from "@workspace/ui/components/popover"
@@ -27,6 +34,13 @@ import {
 import { useCompanies } from "@/hooks/useCompanies"
 import { usePlatforms } from "@/hooks/usePlatforms"
 import { useResumeMap } from "@/hooks/useResumeMap"
+import {
+  CURATED_CURRENCY_CODES,
+  NO_CURRENCY,
+  NO_PAY_PERIOD,
+  PAY_PERIODS,
+  type PayPeriod,
+} from "@/lib/compensation-display"
 import { createApplication, updateApplication } from "@/services/applications.service"
 import type {
   ApplicationCreate,
@@ -45,6 +59,8 @@ interface FormValues {
   platform_id: string
   job_title: string
   salary: string
+  salary_currency: string
+  pay_period: string
   seniority: string
   contract_type: string
   application_url: string
@@ -91,6 +107,10 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
           platform_id: String(selectedApplication.platform_id),
           job_title: selectedApplication.job_title,
           salary: selectedApplication.salary != null ? String(selectedApplication.salary) : "",
+          salary_currency: selectedApplication.salary_currency
+            ? selectedApplication.salary_currency.toUpperCase()
+            : "",
+          pay_period: selectedApplication.pay_period ?? "",
           seniority: selectedApplication.seniority ?? "",
           contract_type: selectedApplication.contract_type ?? "",
           application_url: selectedApplication.application_url ?? "",
@@ -106,6 +126,8 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
           platform_id: "",
           job_title: "",
           salary: "",
+          salary_currency: "",
+          pay_period: "",
           seniority: "",
           contract_type: "",
           application_url: "",
@@ -134,13 +156,30 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
     const companyName = companyInput.trim() || undefined
     const companyId = selectedCompanyId ?? undefined
 
+    const salaryTrim = values.salary.trim()
+    const salaryParsed = salaryTrim === "" ? NaN : parseFloat(salaryTrim)
+    const hasSalary = salaryTrim !== "" && Number.isFinite(salaryParsed)
+
+    if (hasSalary) {
+      if (!values.salary_currency.trim() || !values.pay_period.trim()) {
+        toast.error("Currency and pay period are required when salary is set.")
+        return
+      }
+    }
+
     if (isEdit && selectedApplication) {
       const data: ApplicationUpdate = {
         platform_id: parseInt(values.platform_id),
         job_title: values.job_title.trim(),
         company: companyName,
         company_id: companyId,
-        salary: values.salary ? parseFloat(values.salary) : undefined,
+        salary: hasSalary ? salaryParsed : null,
+        ...(hasSalary
+          ? {
+              salary_currency: values.salary_currency.trim().toUpperCase(),
+              pay_period: values.pay_period as PayPeriod,
+            }
+          : {}),
         seniority: values.seniority.trim() || undefined,
         contract_type: values.contract_type.trim() || undefined,
         application_url: values.application_url.trim() || undefined,
@@ -160,7 +199,13 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
         job_title: values.job_title.trim(),
         company: companyName,
         company_id: companyId,
-        salary: values.salary ? parseFloat(values.salary) : undefined,
+        ...(hasSalary
+          ? {
+              salary: salaryParsed,
+              salary_currency: values.salary_currency.trim().toUpperCase(),
+              pay_period: values.pay_period as PayPeriod,
+            }
+          : {}),
         seniority: values.seniority.trim() || undefined,
         contract_type: values.contract_type.trim() || undefined,
         application_url: values.application_url.trim() || undefined,
@@ -185,6 +230,21 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
   const statusValue = watch("status")
   const platformValue = watch("platform_id")
   const resumeIdValue = watch("resume_id")
+  const payPeriodValue = watch("pay_period")
+  const salaryCurrencyValue = watch("salary_currency")
+
+  const payPeriodSelectValue = payPeriodValue ? payPeriodValue : NO_PAY_PERIOD
+  const currencySelectValue = salaryCurrencyValue ? salaryCurrencyValue : NO_CURRENCY
+
+  const currencyCodesForSelect = useMemo(() => {
+    const c = salaryCurrencyValue?.trim().toUpperCase() ?? ""
+    const base = [...CURATED_CURRENCY_CODES]
+    if (c.length === 3 && /^[A-Z]{3}$/.test(c) && !base.includes(c)) {
+      base.push(c)
+      base.sort()
+    }
+    return base
+  }, [salaryCurrencyValue])
 
   const resumeSelectValue =
     resumeIdValue && resumeIdValue !== "" ? resumeIdValue : NO_RESUME_VALUE
@@ -201,16 +261,16 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-xl max-h-[90vh] overflow-y-auto">
+      <DialogContent className="max-h-[min(90vh,880px)] w-full max-w-[min(100vw-2rem,42rem)] gap-4 overflow-y-auto p-6 sm:max-w-2xl lg:max-w-3xl">
         <DialogHeader>
           <DialogTitle>{isEdit ? "Edit Application" : "New Application"}</DialogTitle>
         </DialogHeader>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-          <div className="space-y-1">
+        <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-5">
+          <div className="flex flex-col gap-1.5">
             <Label>Platform *</Label>
             <Select value={platformValue} onValueChange={(v) => setValue("platform_id", v)}>
-              <SelectTrigger>
+              <SelectTrigger className="w-full min-w-0">
                 <SelectValue placeholder="Select platform" />
               </SelectTrigger>
               <SelectContent>
@@ -223,102 +283,162 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
             </Select>
           </div>
 
-          <div className="space-y-1">
+          <div className="flex flex-col gap-1.5">
             <Label htmlFor="job_title">Job Title *</Label>
             <Input id="job_title" {...register("job_title")} placeholder="e.g. Backend Engineer" />
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div className="flex flex-col gap-1">
-              <Label htmlFor="company-input">Company</Label>
-              <Popover
-                open={companySuggestOpen && filteredCompanies.length > 0}
-                onOpenChange={setCompanySuggestOpen}
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="company-input">Company</Label>
+            <Popover
+              open={companySuggestOpen && filteredCompanies.length > 0}
+              onOpenChange={setCompanySuggestOpen}
+            >
+              <PopoverTrigger asChild>
+                <div className="relative w-full min-w-0">
+                  <Input
+                    id="company-input"
+                    ref={companyInputRef}
+                    className="w-full min-w-0"
+                    value={companyInput}
+                    placeholder="Acme Corp"
+                    autoComplete="off"
+                    onChange={(e) => {
+                      const val = e.target.value
+                      setCompanyInput(val)
+                      if (selectedCompanyId !== null) {
+                        const linked = companies.find((c: CompanyResponse) => c.id === selectedCompanyId)
+                        if (linked && val !== linked.name) {
+                          setSelectedCompanyId(null)
+                        }
+                      }
+                      setCompanySuggestOpen(val.length > 0)
+                    }}
+                    onFocus={() => {
+                      if (companyInput.length > 0 && filteredCompanies.length > 0) {
+                        setCompanySuggestOpen(true)
+                      }
+                    }}
+                  />
+                </div>
+              </PopoverTrigger>
+              <PopoverContent
+                className="w-[var(--radix-popover-trigger-width)] p-0"
+                align="start"
+                onOpenAutoFocus={(e) => e.preventDefault()}
               >
-                <PopoverTrigger asChild>
-                  <div className="relative">
-                    <Input
-                      id="company-input"
-                      ref={companyInputRef}
-                      value={companyInput}
-                      placeholder="Acme Corp"
-                      autoComplete="off"
-                      onChange={(e) => {
-                        const val = e.target.value
-                        setCompanyInput(val)
-                        // If user deviates from the currently selected company name, unlink it
-                        if (selectedCompanyId !== null) {
-                          const linked = companies.find((c: CompanyResponse) => c.id === selectedCompanyId)
-                          if (linked && val !== linked.name) {
-                            setSelectedCompanyId(null)
-                          }
-                        }
-                        setCompanySuggestOpen(val.length > 0)
-                      }}
-                      onFocus={() => {
-                        if (companyInput.length > 0 && filteredCompanies.length > 0) {
-                          setCompanySuggestOpen(true)
-                        }
-                      }}
-                    />
-                  </div>
-                </PopoverTrigger>
-                <PopoverContent
-                  className="w-[var(--radix-popover-trigger-width)] p-0"
-                  align="start"
-                  onOpenAutoFocus={(e) => e.preventDefault()}
-                >
-                  <Command shouldFilter={false}>
-                    <CommandList>
-                      <CommandGroup>
-                        {filteredCompanies.map((c: CompanyResponse) => (
-                          <CommandItem
-                            key={c.id}
-                            value={c.name}
-                            onSelect={() => {
-                              setCompanyInput(c.name)
-                              setSelectedCompanyId(c.id)
-                              setCompanySuggestOpen(false)
-                              companyInputRef.current?.focus()
-                            }}
-                          >
-                            {c.name}
-                          </CommandItem>
-                        ))}
-                      </CommandGroup>
-                    </CommandList>
-                  </Command>
-                </PopoverContent>
-              </Popover>
-              {selectedCompanyId !== null && (
-                <p className="text-xs text-muted-foreground">
-                  Linked to company record
-                </p>
-              )}
-            </div>
-            <div className="flex flex-col gap-1">
-              <Label htmlFor="salary">Salary</Label>
-              <Input id="salary" type="number" step="0.01" {...register("salary")} placeholder="0.00" />
-            </div>
+                <Command shouldFilter={false}>
+                  <CommandList>
+                    <CommandGroup>
+                      {filteredCompanies.map((c: CompanyResponse) => (
+                        <CommandItem
+                          key={c.id}
+                          value={c.name}
+                          onSelect={() => {
+                            setCompanyInput(c.name)
+                            setSelectedCompanyId(c.id)
+                            setCompanySuggestOpen(false)
+                            companyInputRef.current?.focus()
+                          }}
+                        >
+                          {c.name}
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </CommandList>
+                </Command>
+              </PopoverContent>
+            </Popover>
+            {selectedCompanyId !== null && (
+              <p className="text-xs text-muted-foreground">Linked to company record</p>
+            )}
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1">
+          <FieldGroup className="gap-4">
+            <div>
+              <FieldTitle className="text-sm">Compensation</FieldTitle>
+              <FieldDescription>
+                Optional. If you enter an amount, choose currency and pay period.
+              </FieldDescription>
+            </div>
+            <div className="grid w-full min-w-0 grid-cols-1 gap-4 md:grid-cols-3">
+              <Field>
+                <FieldLabel htmlFor="salary">Salary</FieldLabel>
+                <Input
+                  id="salary"
+                  type="number"
+                  step="0.01"
+                  className="w-full min-w-0"
+                  {...register("salary")}
+                  placeholder="0.00"
+                />
+              </Field>
+              <Field>
+                <FieldLabel>Currency</FieldLabel>
+                <Select
+                  value={currencySelectValue}
+                  onValueChange={(v) =>
+                    setValue("salary_currency", v === NO_CURRENCY ? "" : v)
+                  }
+                >
+                  <SelectTrigger className="w-full min-w-0">
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value={NO_CURRENCY}>—</SelectItem>
+                      {currencyCodesForSelect.map((code) => (
+                        <SelectItem key={code} value={code}>
+                          {code}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+              <Field>
+                <FieldLabel>Pay period</FieldLabel>
+                <Select
+                  value={payPeriodSelectValue}
+                  onValueChange={(v) =>
+                    setValue("pay_period", v === NO_PAY_PERIOD ? "" : v)
+                  }
+                >
+                  <SelectTrigger className="w-full min-w-0">
+                    <SelectValue placeholder="Select" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectGroup>
+                      <SelectItem value={NO_PAY_PERIOD}>—</SelectItem>
+                      {PAY_PERIODS.map((p) => (
+                        <SelectItem key={p.value} value={p.value}>
+                          {p.label}
+                        </SelectItem>
+                      ))}
+                    </SelectGroup>
+                  </SelectContent>
+                </Select>
+              </Field>
+            </div>
+          </FieldGroup>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-4">
+            <div className="flex min-w-0 flex-col gap-1.5">
               <Label htmlFor="seniority">Seniority</Label>
               <Input id="seniority" {...register("seniority")} placeholder="e.g. Senior" />
             </div>
-            <div className="space-y-1">
+            <div className="flex min-w-0 flex-col gap-1.5">
               <Label htmlFor="contract_type">Contract Type</Label>
               <Input id="contract_type" {...register("contract_type")} placeholder="e.g. Full-time" />
             </div>
           </div>
 
-          <div className="space-y-1">
+          <div className="flex flex-col gap-1.5">
             <Label htmlFor="application_url">Application URL</Label>
             <Input id="application_url" type="url" {...register("application_url")} placeholder="https://…" />
           </div>
 
-          <div className="space-y-1">
+          <div className="flex flex-col gap-1.5">
             <Label>Resume</Label>
             {resumesLoading ? (
               <p className="text-sm text-muted-foreground">Loading resumes…</p>
@@ -331,7 +451,7 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
                   setValue("resume_id", v === NO_RESUME_VALUE ? "" : v)
                 }
               >
-                <SelectTrigger>
+                <SelectTrigger className="w-full min-w-0">
                   <SelectValue placeholder="No resume" />
                 </SelectTrigger>
                 <SelectContent>
@@ -354,19 +474,19 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
             )}
           </div>
 
-          <div className="grid grid-cols-2 gap-3">
-            <div className="space-y-1">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 sm:gap-4">
+            <div className="flex min-w-0 flex-col gap-1.5">
               <Label>Current Stage {isEdit ? "(read-only)" : "*"}</Label>
               {isEdit ? (
-                <div>
+                <div className="flex flex-col gap-1">
                   <Input value={currentStageValue} readOnly className="cursor-not-allowed opacity-60" />
-                  <p className="mt-1 text-xs text-muted-foreground">
+                  <p className="text-xs text-muted-foreground">
                     Stage changes are made via the History dialog
                   </p>
                 </div>
               ) : (
                 <Select value={currentStageValue} onValueChange={(v) => setValue("current_stage", v)}>
-                  <SelectTrigger>
+                  <SelectTrigger className="w-full min-w-0">
                     <SelectValue placeholder="Select stage" />
                   </SelectTrigger>
                   <SelectContent>
@@ -380,10 +500,10 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
               )}
             </div>
 
-            <div className="space-y-1">
+            <div className="flex min-w-0 flex-col gap-1.5">
               <Label>Status *</Label>
               <Select value={statusValue} onValueChange={(v) => setValue("status", v)}>
-                <SelectTrigger>
+                <SelectTrigger className="w-full min-w-0">
                   <SelectValue placeholder="Select status" />
                 </SelectTrigger>
                 <SelectContent>
@@ -397,12 +517,12 @@ export function ApplicationForm({ selectedApplication, open, onOpenChange, onSuc
             </div>
           </div>
 
-          <div className="space-y-1">
+          <div className="flex flex-col gap-1.5">
             <Label htmlFor="applied_at">Date Applied *</Label>
             <Input id="applied_at" type="date" {...register("applied_at")} />
           </div>
 
-          <div className="flex justify-end gap-2 pt-2">
+          <div className="flex justify-end gap-2 pt-1">
             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
               Cancel
             </Button>

--- a/frontend/apps/web/app/applications/ApplicationTable.tsx
+++ b/frontend/apps/web/app/applications/ApplicationTable.tsx
@@ -43,6 +43,7 @@ import {
 import { cn } from "@workspace/ui/lib/utils"
 import { AppointmentListDialog } from "@/components/AppointmentListDialog"
 import { StageHistoryDialog } from "@/components/StageHistoryDialog"
+import { formatCompensation } from "@/lib/compensation-display"
 import { formatDate } from "@/lib/display"
 import { formatResumeColumn } from "@/lib/formatResumeColumn"
 import { useApplicationsTablePreferences } from "@/hooks/useApplicationsTablePreferences"
@@ -129,7 +130,7 @@ export function ApplicationTable({
   )
 
   const columns = useMemo((): ColumnDef<ApplicationResponse>[] => {
-    const base = [
+    const out: ColumnDef<ApplicationResponse>[] = [
       columnHelper.accessor("job_title", {
         header: "Job Title",
         cell: ({ row, getValue }) => (
@@ -143,32 +144,70 @@ export function ApplicationTable({
           </Button>
         ),
       }),
-      columnHelper.accessor("company", {
-        header: "Company",
-        cell: (info) => info.getValue() ?? <span className="text-muted-foreground">—</span>,
-      }),
       columnHelper.accessor("platform_id", {
         header: "Platform",
         cell: (info) => platforms[info.getValue()] ?? info.getValue(),
       }),
-      columnHelper.accessor("status", {
-        header: "Status",
-        cell: (info) => <Badge variant="outline">{info.getValue()}</Badge>,
+      columnHelper.accessor("company", {
+        header: "Company",
+        cell: (info) => info.getValue() ?? <span className="text-muted-foreground">—</span>,
       }),
-      columnHelper.accessor("current_stage", {
-        header: "Stage",
-        cell: (info) => <Badge variant="secondary">{info.getValue()}</Badge>,
-      }),
-      columnHelper.accessor("applied_at", {
-        header: "Date Applied",
-        cell: (info) => formatDate(info.getValue(), locale),
-      }),
-    ] as ColumnDef<ApplicationResponse>[]
+    ]
 
-    const optional: ColumnDef<ApplicationResponse>[] = []
+    if (tablePrefs.showSeniorityColumn) {
+      out.push(
+        columnHelper.accessor((row) => row.seniority ?? "", {
+          id: "seniority",
+          header: "Seniority",
+          cell: (info) =>
+            info.row.original.seniority ? (
+              info.getValue()
+            ) : (
+              <span className="text-muted-foreground">—</span>
+            ),
+        }) as ColumnDef<ApplicationResponse>,
+      )
+    }
+
+    if (tablePrefs.showSalaryColumn) {
+      out.push(
+        columnHelper.accessor(
+          (row) => {
+            const s = row.salary
+            if (s == null || s === "") return null
+            const n = Number(s)
+            return Number.isNaN(n) ? null : n
+          },
+          {
+            id: "salary",
+            header: "Salary",
+            cell: ({ row }) => {
+              const formatted = formatCompensation({
+                salary: row.original.salary,
+                salary_currency: row.original.salary_currency,
+                pay_period: row.original.pay_period,
+                locale,
+              })
+              if (formatted == null) {
+                return <span className="text-muted-foreground">—</span>
+              }
+              return <span className="max-w-[14rem] truncate" title={formatted}>{formatted}</span>
+            },
+            sortingFn: (a, b, columnId) => {
+              const av = a.getValue(columnId) as number | null
+              const bv = b.getValue(columnId) as number | null
+              if (av == null && bv == null) return 0
+              if (av == null) return 1
+              if (bv == null) return -1
+              return av === bv ? 0 : av < bv ? -1 : 1
+            },
+          },
+        ) as ColumnDef<ApplicationResponse>,
+      )
+    }
 
     if (tablePrefs.showResumeColumn) {
-      optional.push(
+      out.push(
         columnHelper.accessor((row) => formatResumeColumn(row.resume_id, resumeMap), {
           id: "resume",
           header: "Resume",
@@ -188,59 +227,23 @@ export function ApplicationTable({
       )
     }
 
-    if (tablePrefs.showSalaryColumn) {
-      optional.push(
-        columnHelper.accessor(
-          (row) => {
-            const s = row.salary
-            if (s == null || s === "") return null
-            const n = Number(s)
-            return Number.isNaN(n) ? null : n
-          },
-          {
-            id: "salary",
-            header: "Salary",
-            cell: ({ row }) => {
-              const s = row.original.salary
-              if (s == null || s === "") {
-                return <span className="text-muted-foreground">—</span>
-              }
-              const n = Number(s)
-              if (Number.isNaN(n)) {
-                return <span className="text-muted-foreground">—</span>
-              }
-              return new Intl.NumberFormat(locale, { maximumFractionDigits: 2 }).format(n)
-            },
-            sortingFn: (a, b, columnId) => {
-              const av = a.getValue(columnId) as number | null
-              const bv = b.getValue(columnId) as number | null
-              if (av == null && bv == null) return 0
-              if (av == null) return 1
-              if (bv == null) return -1
-              return av === bv ? 0 : av < bv ? -1 : 1
-            },
-          },
-        ) as ColumnDef<ApplicationResponse>,
-      )
-    }
-
-    if (tablePrefs.showSeniorityColumn) {
-      optional.push(
-        columnHelper.accessor((row) => row.seniority ?? "", {
-          id: "seniority",
-          header: "Seniority",
-          cell: (info) =>
-            info.row.original.seniority ? (
-              info.getValue()
-            ) : (
-              <span className="text-muted-foreground">—</span>
-            ),
-        }) as ColumnDef<ApplicationResponse>,
-      )
-    }
+    out.push(
+      columnHelper.accessor("current_stage", {
+        header: "Stage",
+        cell: (info) => <Badge variant="secondary">{info.getValue()}</Badge>,
+      }),
+      columnHelper.accessor("status", {
+        header: "Status",
+        cell: (info) => <Badge variant="outline">{info.getValue()}</Badge>,
+      }),
+      columnHelper.accessor("applied_at", {
+        header: "Date Applied",
+        cell: (info) => formatDate(info.getValue(), locale),
+      }),
+    )
 
     if (tablePrefs.showCreatedAtColumn) {
-      optional.push(
+      out.push(
         columnHelper.accessor("created_at", {
           id: "created_at",
           header: "Created",
@@ -389,7 +392,8 @@ export function ApplicationTable({
       },
     }) as ColumnDef<ApplicationResponse>
 
-    return [...base, ...optional, actions]
+    out.push(actions)
+    return out
   }, [tablePrefs, platforms, resumeMap, locale, archived, onEdit, handleArchive, handleRestore, handleDelete])
 
   const table = useReactTable({

--- a/frontend/apps/web/app/settings/ApplicationsTablePreferencesCard.tsx
+++ b/frontend/apps/web/app/settings/ApplicationsTablePreferencesCard.tsx
@@ -42,7 +42,9 @@ export function ApplicationsTablePreferencesCard() {
             <div className="flex items-center justify-between gap-4">
               <div className="flex flex-col gap-1">
                 <FieldLabel>Salary column</FieldLabel>
-                <p className="text-xs text-muted-foreground">Show stored salary when present.</p>
+                <p className="text-xs text-muted-foreground">
+                  Show compensation (amount, currency, pay period) when present.
+                </p>
               </div>
               <Switch
                 checked={prefs.showSalaryColumn}

--- a/frontend/apps/web/lib/compensation-display.ts
+++ b/frontend/apps/web/lib/compensation-display.ts
@@ -1,0 +1,90 @@
+export type PayPeriod = "annual" | "monthly" | "hourly"
+
+export const PAY_PERIODS: { value: PayPeriod; label: string }[] = [
+  { value: "annual", label: "Annual" },
+  { value: "monthly", label: "Monthly" },
+  { value: "hourly", label: "Hourly" },
+]
+
+/** Sentinel for Select when no value (Radix Select disallows empty string). */
+export const NO_PAY_PERIOD = "__none__"
+export const NO_CURRENCY = "__none__"
+
+const PERIOD_SUFFIX: Record<PayPeriod, string> = {
+  annual: "/yr",
+  monthly: "/mo",
+  hourly: "/hr",
+}
+
+function isPayPeriod(v: string | null | undefined): v is PayPeriod {
+  return v === "annual" || v === "monthly" || v === "hourly"
+}
+
+export const CURATED_CURRENCY_CODES: string[] = [
+  "AUD",
+  "BRL",
+  "CAD",
+  "CHF",
+  "CNY",
+  "CZK",
+  "DKK",
+  "EUR",
+  "GBP",
+  "HKD",
+  "HUF",
+  "ILS",
+  "INR",
+  "JPY",
+  "KRW",
+  "MXN",
+  "NOK",
+  "NZD",
+  "PLN",
+  "SEK",
+  "SGD",
+  "USD",
+  "ZAR",
+].sort()
+
+export interface FormatCompensationInput {
+  salary: string | number | null | undefined
+  salary_currency: string | null | undefined
+  pay_period: string | null | undefined
+  locale: string
+}
+
+export function formatCompensation(input: FormatCompensationInput): string | null {
+  const raw = input.salary
+  if (raw == null || raw === "") {
+    return null
+  }
+  const n = typeof raw === "number" ? raw : Number(raw)
+  if (Number.isNaN(n)) {
+    return null
+  }
+
+  const currency = input.salary_currency?.trim().toUpperCase() || null
+  const period = input.pay_period
+  const suffix = isPayPeriod(period) ? PERIOD_SUFFIX[period] : ""
+
+  let base: string
+  if (currency && /^[A-Z]{3}$/.test(currency)) {
+    try {
+      base = new Intl.NumberFormat(input.locale, {
+        style: "currency",
+        currency,
+        maximumFractionDigits: 2,
+      }).format(n)
+    } catch {
+      base = new Intl.NumberFormat(input.locale, { maximumFractionDigits: 2 }).format(n)
+      if (suffix) {
+        return `${base} ${currency}${suffix}`
+      }
+      return currency ? `${base} ${currency}` : base
+    }
+  } else {
+    base = new Intl.NumberFormat(input.locale, { maximumFractionDigits: 2 }).format(n)
+  }
+
+  return suffix ? `${base}${suffix}` : base
+}

--- a/frontend/apps/web/types/api.generated.ts
+++ b/frontend/apps/web/types/api.generated.ts
@@ -463,6 +463,10 @@ export interface components {
             company?: string | null;
             /** Salary */
             salary?: number | string | null;
+            /** Salary Currency */
+            salary_currency?: string | null;
+            /** Pay Period */
+            pay_period?: "annual" | "monthly" | "hourly" | null;
             /** Seniority */
             seniority?: string | null;
             /** Contract Type */
@@ -539,6 +543,10 @@ export interface components {
             company_id: number | null;
             /** Salary */
             salary: string | null;
+            /** Salary Currency */
+            salary_currency: string | null;
+            /** Pay Period */
+            pay_period: string | null;
             /** Seniority */
             seniority: string | null;
             /** Contract Type */
@@ -579,6 +587,10 @@ export interface components {
             company?: string | null;
             /** Salary */
             salary?: number | string | null;
+            /** Salary Currency */
+            salary_currency?: string | null;
+            /** Pay Period */
+            pay_period?: "annual" | "monthly" | "hourly" | null;
             /** Seniority */
             seniority?: string | null;
             /** Contract Type */


### PR DESCRIPTION
### Summary
Adds structured compensation on applications (amount + ISO 4217 currency + annual/monthly/hourly pay period) with API validation and coherent clearing when salary is removed. Improves the New/Edit Application dialog layout (wider modal, full-width selects, company separated from compensation). Reorders applications table columns to Job title → Platform → Company → optional columns → Stage → Status → Date applied. 

### Changes
- **Backend:** Alembic migration `add_salary_currency_pay_period`; `application.salary_currency`, `application.pay_period`; Pydantic validators and salary/currency/period rules on create/update; `_normalize_salary_fields` in application service; `docs/backend.md` updated (wire format, schemas, service).
- **Frontend:** `compensation-display.ts` (`formatCompensation`, curated currencies, pay periods); `ApplicationForm` compensation fields + validation; `ApplicationDetailDialog` and optional salary column use `formatCompensation`; `api.generated.ts` fields for new API properties; Vitest updates + `compensation-display.test.ts`; wider `DialogContent` and `SelectTrigger` `w-full` on form.
- **Applications table:** Column order: Job title, Platform, Company, then optional Seniority / Salary / Resume, then Stage, Status, Date applied, optional Created, Actions.

### Notes
- Closes #10 